### PR TITLE
Fix false 'enter assessment name' error on Save/Download

### DIFF
--- a/index.html
+++ b/index.html
@@ -1638,7 +1638,11 @@ function saveConfiguration() {
 function collectData() {
   const getLabel = (text) => {
     for (const l of document.querySelectorAll('.field label')) {
-      if (l.textContent.trim() === text) {
+      const labelText = Array.from(l.childNodes)
+        .filter(n => n.nodeType === Node.TEXT_NODE)
+        .map(n => n.textContent)
+        .join('').trim();
+      if (labelText === text) {
         const inp = l.parentElement.querySelector('input,select');
         return inp ? inp.value.trim() : '';
       }


### PR DESCRIPTION
getLabel() was comparing l.textContent (which includes child element text like the * span) against the bare label string, so the match always failed after required-star spans were added to labels.

Fix: compare only direct text-node content, ignoring child elements.

https://claude.ai/code/session_01HXqdo82o56tQvQaBFVk3Yi